### PR TITLE
Fix NNGException when msg port is not ready yet

### DIFF
--- a/clients/python/wcferry/client.py
+++ b/clients/python/wcferry/client.py
@@ -518,7 +518,6 @@ class Wcf():
         """允许接收消息，成功后通过 `get_msg` 读取消息"""
         def listening_msg():
             rsp = wcf_pb2.Response()
-            self.msg_socket.dial(self.msg_url, block=True)
             while self._is_receiving_msg:
                 try:
                     rsp.ParseFromString(self.msg_socket.recv_msg().bytes)
@@ -539,6 +538,19 @@ class Wcf():
         rsp = self._send_request(req)
         if rsp.status != 0:
             return False
+
+        fail_cnt = 0
+        while True:
+            try:
+                self.msg_socket.dial(self.msg_url, block=True)
+                break
+            except pynng.exceptions.NNGException as e:
+                if fail_cnt > 50:
+                    raise e
+                fail_cnt += 1
+                sleep(0.1) # 等待消息端口启动监听
+            except Exception as e:
+                raise e
 
         self._is_receiving_msg = True
         # 阻塞，把控制权交给用户


### PR DESCRIPTION
* 代码位置
  clients/python/wcferry/client.py：enable_receiving_msg
* 问题
  在连接消息端口时，有概率出现消息端口还没有启动监听，导致GetMessage线程出现异常：
  pynng.exceptions.NNGException: Connection shutdown
* 解决方案
  增加循环sleep等待