### PR TITLE
修复 server 端log处理

### DIFF
--- a/WeChatFerry/com/log.cpp
+++ b/WeChatFerry/com/log.cpp
@@ -14,7 +14,11 @@ void InitLogger(std::string path)
     if (logger != nullptr) {
         return;
     }
-
+    // check and create logs folder
+    std::filesystem::path logDir = std::filesystem::path(path) / "logs";
+    if (!std::filesystem::exists(logDir)) {
+        std::filesystem::create_directory(logDir);
+    }
     auto filename = std::filesystem::path(path + LOGGER_FILE_NAME).make_preferred().string();
     try {
         logger = spdlog::rotating_logger_mt(LOGGER_NAME, filename, LOGGER_MAX_SIZE, LOGGER_MAX_FILES);

--- a/WeChatFerry/sdk/SDK.vcxproj
+++ b/WeChatFerry/sdk/SDK.vcxproj
@@ -117,6 +117,7 @@
       <PrecompiledHeaderOutputFile />
       <SupportJustMyCode>true</SupportJustMyCode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/WeChatFerry/spy/Spy.vcxproj
+++ b/WeChatFerry/spy/Spy.vcxproj
@@ -96,7 +96,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeaderOutputFile />
       <DisableSpecificWarnings>4251;4731;4819</DisableSpecificWarnings>
-      <AdditionalOptions>/EHa %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/EHa /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -192,7 +192,7 @@ xcopy /y $(OutDir)$(TargetFileName) $(SolutionDir)..\clients\python\wcferry</Com
       <OmitFramePointers>false</OmitFramePointers>
       <PrecompiledHeaderOutputFile />
       <DisableSpecificWarnings>4251;4731;4819</DisableSpecificWarnings>
-      <AdditionalOptions>/EHa %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/EHa /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/clients/python/wcferry/client.py
+++ b/clients/python/wcferry/client.py
@@ -69,6 +69,9 @@ class Wcf():
         self._wcf_root = os.path.abspath(os.path.dirname(__file__))
         self._dl_path = f"{self._wcf_root}/.dl"
         os.makedirs(self._dl_path, exist_ok=True)
+        # 在脚本所在目录创建logs文件夹
+        if not os.path.exists('logs'):
+            os.mkdir('logs')
         self.LOG = logging.getLogger("WCF")
         self.LOG.info(f"wcferry version: {__version__}")
         self.port = port
@@ -276,7 +279,7 @@ class Wcf():
             sleep(1)
             cnt += 1
 
-        self.LOG.error(f"获取超时")
+        self.LOG.error("获取超时")
         return ""
 
     def send_text(self, msg: str, receiver: str, aters: Optional[str] = "") -> int:
@@ -302,7 +305,7 @@ class Wcf():
     def _download_file(self, url: str) -> str:
         path = None
         if not self._local_mode:
-            self.LOG.error(f"只有本地模式才支持网络路径！")
+            self.LOG.error("只有本地模式才支持网络路径！")
             return path
 
         try:
@@ -834,7 +837,7 @@ class Wcf():
             str: 成功返回存储路径；空字符串为失败，原因见日志。
         """
         if self.download_attach(id, "", extra) != 0:
-            self.LOG.error(f"下载失败")
+            self.LOG.error("下载失败")
             return ""
         cnt = 0
         while cnt < timeout:
@@ -844,7 +847,7 @@ class Wcf():
             sleep(1)
             cnt += 1
 
-        self.LOG.error(f"下载超时")
+        self.LOG.error("下载超时")
         return ""
 
     def add_chatroom_members(self, roomid: str, wxids: str) -> int:

--- a/clients/python/wcferry/client.py
+++ b/clients/python/wcferry/client.py
@@ -69,9 +69,6 @@ class Wcf():
         self._wcf_root = os.path.abspath(os.path.dirname(__file__))
         self._dl_path = f"{self._wcf_root}/.dl"
         os.makedirs(self._dl_path, exist_ok=True)
-        # 在脚本所在目录创建logs文件夹
-        if not os.path.exists('logs'):
-            os.mkdir('logs')
         self.LOG = logging.getLogger("WCF")
         self.LOG.info(f"wcferry version: {__version__}")
         self.port = port


### PR DESCRIPTION
首先感谢作者提供wcf这么好的工具，实在是太好用了。比模拟键鼠要方便很多。

目前主要用python的客户端，在使用中发现脚本启动时需要创建logs文件，否则微信（版本：3.9.10.27）将报错（报告异常）。

本次br主要是：1、调用sdk前创建logs文件夹。2、删掉了几处没有fomat内容的f字符。

![报错](https://github.com/user-attachments/assets/0ff3e1f9-f5a2-4b8a-8db2-fc5346bb1958)

![句柄情况](https://github.com/user-attachments/assets/292703b1-3d90-404e-b37a-ce99c1742ae1)

