### PR TITLE
修复因无logs文件夹导致启动失败的问题。c++项目增加 /utf8兼容，解决编码异常问题。

### DIFF
--- a/WeChatFerry/com/log.cpp
+++ b/WeChatFerry/com/log.cpp
@@ -14,7 +14,11 @@ void InitLogger(std::string path)
     if (logger != nullptr) {
         return;
     }
-
+    // check and create logs folder
+    std::filesystem::path logDir = std::filesystem::path(path) / "logs";
+    if (!std::filesystem::exists(logDir)) {
+        std::filesystem::create_directory(logDir);
+    }
     auto filename = std::filesystem::path(path + LOGGER_FILE_NAME).make_preferred().string();
     try {
         logger = spdlog::rotating_logger_mt(LOGGER_NAME, filename, LOGGER_MAX_SIZE, LOGGER_MAX_FILES);

--- a/WeChatFerry/sdk/SDK.vcxproj
+++ b/WeChatFerry/sdk/SDK.vcxproj
@@ -117,6 +117,7 @@
       <PrecompiledHeaderOutputFile />
       <SupportJustMyCode>true</SupportJustMyCode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/WeChatFerry/spy/Spy.vcxproj
+++ b/WeChatFerry/spy/Spy.vcxproj
@@ -192,7 +192,7 @@ xcopy /y $(OutDir)$(TargetFileName) $(SolutionDir)..\clients\python\wcferry</Com
       <OmitFramePointers>false</OmitFramePointers>
       <PrecompiledHeaderOutputFile />
       <DisableSpecificWarnings>4251;4731;4819</DisableSpecificWarnings>
-      <AdditionalOptions>/EHa %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/EHa /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>


### PR DESCRIPTION
同时，项目增加/utf-8配置项，解决以下问题导致的无法编译：
```
1>Generating PB files
1>cl : 命令行 warning D9025: 正在重写“/EHs”(用“/EHa”)
1>log.cpp
1>C:\Tools\vcpkg\installed\x64-windows-static\include\fmt\base.h(458,28): error C2338: Unicode support requires compiling with /utf-8
1>util.cpp
1>C:\Tools\vcpkg\installed\x64-windows-static\include\fmt\base.h(458,28): error C2338: Unicode support requires compiling with /utf-8
1>pb_util.cpp
```